### PR TITLE
Configure frontend for web deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Aplicación Fullstack para gestionar productos y órdenes, con un backend en Nod
 - Asociar productos a órdenes con cantidades.  
 
 ## Instalación rápida
+
 ```bash
 # Backend
 cd backend
@@ -24,3 +25,10 @@ npm run dev   # Servidor en http://localhost:4000/api
 cd frontend
 npm install
 npm run dev   # App en http://localhost:5173
+```
+
+## Variables de entorno para despliegue
+
+1. Copia `frontend/.env.example` como `frontend/.env`.
+2. Ajusta `VITE_API_URL` con la URL pública de tu backend (incluye el sufijo `/api`).
+3. Ejecuta `npm run build` dentro de `frontend` y sirve la carpeta `dist` generada.

--- a/fractal-challenge/frontend/.env.example
+++ b/fractal-challenge/frontend/.env.example
@@ -1,0 +1,2 @@
+# URL base del backend expuesta para el frontend (incluye /api)
+VITE_API_URL=http://localhost:4000/api

--- a/fractal-challenge/frontend/postcss.config.js
+++ b/fractal-challenge/frontend/postcss.config.js
@@ -1,6 +1,6 @@
+import tailwindcss from "@tailwindcss/postcss";
+import autoprefixer from "autoprefixer";
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+  plugins: [tailwindcss, autoprefixer],
+};

--- a/fractal-challenge/frontend/src/api.js
+++ b/fractal-challenge/frontend/src/api.js
@@ -1,9 +1,19 @@
 // src/api.js
 import axios from "axios";
 
-// 🔹 Crear instancia de axios con la URL base de tu backend
+// 🔹 Permite definir la URL del backend mediante variables de entorno en build
+const envBaseUrl = import.meta.env.VITE_API_URL?.trim();
+
+// 🔹 Fallbacks:
+//    - entorno local: usa el backend en localhost:4000
+//    - producción sin variable: asume mismo dominio del frontend (ruta /api)
+const defaultBaseUrl =
+  typeof window !== "undefined" && window.location.hostname === "localhost"
+    ? "http://localhost:4000/api"
+    : "/api";
+
 const api = axios.create({
-  baseURL: "http://localhost:4000/api",
+  baseURL: envBaseUrl || defaultBaseUrl,
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
## Summary
- allow the frontend API client to read the backend base URL from `VITE_API_URL` with sensible fallbacks for local and production builds
- add deployment notes and a sample `.env` file documenting how to configure the frontend
- update the PostCSS configuration to use the Tailwind CSS v4 plugin so production builds succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9990352f4832fbbad023a1e324a2d