### PR TITLE
Configure frontend for web deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ npm run dev   # App en http://localhost:5173
 4. Si tu proveedor requiere TLS, activa `DB_SSL=true` para que la conexión utilice SSL.
 5. (Opcional) Ajusta `DB_POOL_LIMIT` si necesitas controlar la cantidad máxima de conexiones simultáneas que abrirá el backend.
 6. Inicia el servidor con `npm run start` (o configura el proceso según tu plataforma de despliegue) y asegúrate de que la aplicación frontend apunte a la ruta pública del backend (`/api`).
+7. Para un despliegue en el mismo servidor (localhost) basta con que MySQL esté corriendo en `localhost:3306`. El backend intentará crear la base de datos `fractal_db` y las tablas requeridas al arrancar si la cuenta tiene privilegios de creación. Si tu proveedor bloquea esas operaciones, define `DB_PREPARE=false` y gestiona el esquema manualmente.
+
+#### ¿Sin MySQL instalado?
+
+Puedes crear una instancia local rápidamente con Docker:
+
+```bash
+docker run --name fractal-mysql \
+  -e MYSQL_ROOT_PASSWORD=fractal \
+  -e MYSQL_DATABASE=fractal_db \
+  -p 3306:3306 -d mysql:8.0
+```
+
+Luego actualiza `backend/.env` con `DB_PASSWORD=fractal` (o usa el usuario que prefieras). Al iniciar el backend se crearán automáticamente las tablas necesarias.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Aplicación Fullstack para gestionar productos y órdenes, con un backend en Nod
 - Asociar productos a órdenes con cantidades.  
 
 ## Instalación rápida
+
 ```bash
 # Backend
 cd backend
@@ -24,3 +25,21 @@ npm run dev   # Servidor en http://localhost:4000/api
 cd frontend
 npm install
 npm run dev   # App en http://localhost:5173
+```
+
+## Variables de entorno para despliegue
+
+### Frontend
+
+1. Copia `frontend/.env.example` como `frontend/.env`.
+2. Ajusta `VITE_API_URL` con la URL pública de tu backend (incluye el sufijo `/api`).
+3. Ejecuta `npm run build` dentro de `frontend` y sirve la carpeta `dist` generada.
+
+### Backend
+
+1. Copia `backend/.env.example` como `backend/.env`.
+2. Si tu base de datos está en la nube, reemplaza las variables (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME`) con las credenciales provistas.
+3. Alternativamente puedes pegar la cadena completa que entregan servicios como PlanetScale, Railway o Clever Cloud en `DB_URL` (`mysql://usuario:clave@host:puerto/base`). También se aceptan `DATABASE_URL` y `CLEARDB_DATABASE_URL`.
+4. Si tu proveedor requiere TLS, activa `DB_SSL=true` para que la conexión utilice SSL.
+5. (Opcional) Ajusta `DB_POOL_LIMIT` si necesitas controlar la cantidad máxima de conexiones simultáneas que abrirá el backend.
+6. Inicia el servidor con `npm run start` (o configura el proceso según tu plataforma de despliegue) y asegúrate de que la aplicación frontend apunte a la ruta pública del backend (`/api`).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm run dev   # App en http://localhost:5173
 ### Backend
 
 1. Copia `backend/.env.example` como `backend/.env`.
-2. Si tu base de datos está en la nube, reemplaza las variables (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME`) con las credenciales provistas.
+2. Si tu base de datos está en la nube, reemplaza las variables (`DB_HOST`, `DB_PORT`, `DB_USER`/`DB_USERNAME`, `DB_PASS`/`DB_PASSWORD`, `DB_NAME`/`DB_DATABASE`) con las credenciales provistas.
 3. Alternativamente puedes pegar la cadena completa que entregan servicios como PlanetScale, Railway o Clever Cloud en `DB_URL` (`mysql://usuario:clave@host:puerto/base`). También se aceptan `DATABASE_URL` y `CLEARDB_DATABASE_URL`.
 4. Si tu proveedor requiere TLS, activa `DB_SSL=true` para que la conexión utilice SSL.
 5. (Opcional) Ajusta `DB_POOL_LIMIT` si necesitas controlar la cantidad máxima de conexiones simultáneas que abrirá el backend.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm run dev   # App en http://localhost:5173
 1. Copia `backend/.env.example` como `backend/.env`.
 2. Si tu base de datos está en la nube, reemplaza las variables (`DB_HOST`, `DB_PORT`, `DB_USER`/`DB_USERNAME`, `DB_PASS`/`DB_PASSWORD`, `DB_NAME`/`DB_DATABASE`) con las credenciales provistas.
 3. Alternativamente puedes pegar la cadena completa que entregan servicios como PlanetScale, Railway o Clever Cloud en `DB_URL` (`mysql://usuario:clave@host:puerto/base`). También se aceptan `DATABASE_URL` y `CLEARDB_DATABASE_URL`.
-4. Si tu proveedor requiere TLS, activa `DB_SSL=true` para que la conexión utilice SSL.
+4. Si tu proveedor requiere TLS, activa `DB_SSL=true` para que la conexión utilice SSL. Si el host termina en `.proxy.rlwy.net` o `.railway.app` (como en Railway), el backend activará SSL automáticamente aunque no definas la variable.
 5. (Opcional) Ajusta `DB_POOL_LIMIT` si necesitas controlar la cantidad máxima de conexiones simultáneas que abrirá el backend.
 6. Inicia el servidor con `npm run start` (o configura el proceso según tu plataforma de despliegue) y asegúrate de que la aplicación frontend apunte a la ruta pública del backend (`/api`).
 7. Para un despliegue en el mismo servidor (localhost) basta con que MySQL esté corriendo en `localhost:3306`. El backend intentará crear la base de datos `fractal_db` y las tablas requeridas al arrancar si la cuenta tiene privilegios de creación. Si tu proveedor bloquea esas operaciones, define `DB_PREPARE=false` y gestiona el esquema manualmente.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run dev   # App en http://localhost:5173
 ### Frontend
 
 1. Copia `frontend/.env.example` como `frontend/.env`.
-2. Ajusta `VITE_API_URL` con la URL pública de tu backend (incluye el sufijo `/api`).
+2. Ajusta `VITE_API_URL` con la URL pública de tu backend (incluye el sufijo `/api`). Si ya tienes configuradas variables como `VITE_BACKEND_URL`, `PUBLIC_API_URL` o `API_URL` en tu plataforma de despliegue, el build también las tomará como alias.
 3. Ejecuta `npm run build` dentro de `frontend` y sirve la carpeta `dist` generada.
 
 ### Backend

--- a/fractal-challenge/backend/.env.example
+++ b/fractal-challenge/backend/.env.example
@@ -16,3 +16,6 @@ DB_NAME=fractal_db
 
 # (Opcional) Ajusta el tamaño del pool de conexiones del servidor
 # DB_POOL_LIMIT=10
+
+# (Opcional) Desactiva la creación automática de base de datos y tablas
+# DB_PREPARE=false

--- a/fractal-challenge/backend/.env.example
+++ b/fractal-challenge/backend/.env.example
@@ -1,0 +1,15 @@
+# Credenciales para una instancia local de MySQL
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASS=
+DB_NAME=fractal_db
+
+# (Opcional) Cadena de conexión completa si tu proveedor la entrega
+# DB_URL=mysql://usuario:clave@host:3306/fractal_db
+
+# (Opcional) Activa SSL para proveedores como PlanetScale o Clever Cloud
+# DB_SSL=true
+
+# (Opcional) Ajusta el tamaño del pool de conexiones del servidor
+# DB_POOL_LIMIT=10

--- a/fractal-challenge/backend/.env.example
+++ b/fractal-challenge/backend/.env.example
@@ -19,3 +19,11 @@ DB_NAME=fractal_db
 
 # (Opcional) Desactiva la creación automática de base de datos y tablas
 # DB_PREPARE=false
+
+# Ejemplo para una instancia de Railway (reemplaza la contraseña real)
+# DB_HOST=switchyard.proxy.rlwy.net
+# DB_PORT=20511
+# DB_USER=root
+# DB_PASSWORD=tu_contraseña
+# DB_NAME=railway
+# DB_SSL=true

--- a/fractal-challenge/backend/.env.example
+++ b/fractal-challenge/backend/.env.example
@@ -2,8 +2,11 @@
 DB_HOST=localhost
 DB_PORT=3306
 DB_USER=root
-DB_PASS=
+# DB_USERNAME=root
+DB_PASSWORD=
+# DB_PASS=
 DB_NAME=fractal_db
+# DB_DATABASE=fractal_db
 
 # (Opcional) Cadena de conexión completa si tu proveedor la entrega
 # DB_URL=mysql://usuario:clave@host:3306/fractal_db

--- a/fractal-challenge/backend/src/db.js
+++ b/fractal-challenge/backend/src/db.js
@@ -3,6 +3,15 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+const pickEnv = (...keys) => {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+      return process.env[key];
+    }
+  }
+  return undefined;
+};
+
 const parsePositiveInt = (value, fallback) => {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -44,11 +53,11 @@ const parseConnectionString = (urlString) => {
 const connectionConfig = connectionString
   ? parseConnectionString(connectionString)
   : {
-      host: process.env.DB_HOST || "localhost",
-      port: parsePositiveInt(process.env.DB_PORT, 3306),
-      user: process.env.DB_USER || "root",
-      password: process.env.DB_PASS || "",
-      database: process.env.DB_NAME || "fractal_db",
+      host: pickEnv("DB_HOST", "DATABASE_HOST") || "localhost",
+      port: parsePositiveInt(pickEnv("DB_PORT", "DATABASE_PORT"), 3306),
+      user: pickEnv("DB_USER", "DB_USERNAME") || "root",
+      password: pickEnv("DB_PASS", "DB_PASSWORD") || "",
+      database: pickEnv("DB_NAME", "DB_DATABASE") || "fractal_db",
     };
 
 const shouldUseSsl = (process.env.DB_SSL || "").toLowerCase() === "true";

--- a/fractal-challenge/backend/src/db.js
+++ b/fractal-challenge/backend/src/db.js
@@ -3,9 +3,64 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-export const db = await mysql.createPool({
-  host: process.env.DB_HOST || "localhost",
-  user: process.env.DB_USER || "root",
-  password: process.env.DB_PASS || "",
-  database: process.env.DB_NAME || "fractal_db"
-});
+const parsePositiveInt = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const connectionString =
+  process.env.DB_URL ||
+  process.env.DATABASE_URL ||
+  process.env.CLEARDB_DATABASE_URL;
+
+const parseConnectionString = (urlString) => {
+  try {
+    const url = new URL(urlString);
+    const sslParam =
+      url.searchParams.get("ssl") ||
+      url.searchParams.get("sslmode") ||
+      url.searchParams.get("ssl-mode");
+    const wantsSsl =
+      typeof sslParam === "string" &&
+      ["1", "true", "require", "required", "verify_ca", "verify_identity", "verify_full"].includes(
+        sslParam.toLowerCase()
+      );
+
+    return {
+      host: url.hostname,
+      port: parsePositiveInt(url.port, 3306),
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+      database: url.pathname.replace(/^\//, ""),
+      ...(wantsSsl ? { ssl: { rejectUnauthorized: false } } : {}),
+    };
+  } catch (error) {
+    throw new Error(
+      "No se pudo interpretar la cadena de conexión definida en DB_URL/DATABASE_URL"
+    );
+  }
+};
+
+const connectionConfig = connectionString
+  ? parseConnectionString(connectionString)
+  : {
+      host: process.env.DB_HOST || "localhost",
+      port: parsePositiveInt(process.env.DB_PORT, 3306),
+      user: process.env.DB_USER || "root",
+      password: process.env.DB_PASS || "",
+      database: process.env.DB_NAME || "fractal_db",
+    };
+
+const shouldUseSsl = (process.env.DB_SSL || "").toLowerCase() === "true";
+
+const poolConfig = {
+  waitForConnections: true,
+  connectionLimit: parsePositiveInt(process.env.DB_POOL_LIMIT, 10),
+  ...connectionConfig,
+};
+
+if (shouldUseSsl && !poolConfig.ssl) {
+  poolConfig.ssl = { rejectUnauthorized: false };
+}
+
+export const db = await mysql.createPool(poolConfig);

--- a/fractal-challenge/frontend/.env.example
+++ b/fractal-challenge/frontend/.env.example
@@ -1,2 +1,3 @@
 # URL base del backend expuesta para el frontend (incluye /api)
+# También se aceptan los alias VITE_BACKEND_URL, PUBLIC_API_URL o API_URL
 VITE_API_URL=http://localhost:4000/api

--- a/fractal-challenge/frontend/.env.example
+++ b/fractal-challenge/frontend/.env.example
@@ -1,0 +1,2 @@
+# URL base del backend expuesta para el frontend (incluye /api)
+VITE_API_URL=http://localhost:4000/api

--- a/fractal-challenge/frontend/postcss.config.js
+++ b/fractal-challenge/frontend/postcss.config.js
@@ -1,6 +1,6 @@
+import tailwindcss from "@tailwindcss/postcss";
+import autoprefixer from "autoprefixer";
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+  plugins: [tailwindcss, autoprefixer],
+};

--- a/fractal-challenge/frontend/src/App.jsx
+++ b/fractal-challenge/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, NavLink } from "react-router-dom";
+import { HashRouter as Router, Routes, Route, NavLink, Navigate } from "react-router-dom";
 import ProductsPage from "./pages/ProductsPage";
 import OrdersPage from "./pages/OrdersPage";
 import OrderProductsPage from "./pages/OrderProductsPage";
@@ -48,10 +48,11 @@ function App() {
         {/* 🔹 Contenido */}
         <div className="container mx-auto px-6 py-8">
           <Routes>
-            <Route path="/" element={<ProductsPage />} />
+            <Route path="/" element={<Navigate to="/products" replace />} />
             <Route path="/products" element={<ProductsPage />} />
             <Route path="/orders" element={<OrdersPage />} />
             <Route path="/order-products" element={<OrderProductsPage />} />
+            <Route path="*" element={<Navigate to="/products" replace />} />
           </Routes>
         </div>
       </div>

--- a/fractal-challenge/frontend/src/api.js
+++ b/fractal-challenge/frontend/src/api.js
@@ -1,9 +1,19 @@
 // src/api.js
 import axios from "axios";
 
-// 🔹 Crear instancia de axios con la URL base de tu backend
+// 🔹 Permite definir la URL del backend mediante variables de entorno en build
+const envBaseUrl = import.meta.env.VITE_API_URL?.trim();
+
+// 🔹 Fallbacks:
+//    - entorno local: usa el backend en localhost:4000
+//    - producción sin variable: asume mismo dominio del frontend (ruta /api)
+const defaultBaseUrl =
+  typeof window !== "undefined" && window.location.hostname === "localhost"
+    ? "http://localhost:4000/api"
+    : "/api";
+
 const api = axios.create({
-  baseURL: "http://localhost:4000/api",
+  baseURL: envBaseUrl || defaultBaseUrl,
   headers: {
     "Content-Type": "application/json",
   },

--- a/fractal-challenge/frontend/src/api.js
+++ b/fractal-challenge/frontend/src/api.js
@@ -2,15 +2,24 @@
 import axios from "axios";
 
 // 🔹 Permite definir la URL del backend mediante variables de entorno en build
-const envBaseUrl = import.meta.env.VITE_API_URL?.trim();
+//    - Reutiliza el nombre actual (VITE_API_URL) y los alias previos (p. ej. VITE_BACKEND_URL)
+//    - También acepta variables genéricas como PUBLIC_API_URL o API_URL que algunos hosts exponen automáticamente
+const envBaseUrl = [
+  import.meta.env.VITE_API_URL,
+  import.meta.env.VITE_BACKEND_URL,
+  import.meta.env.PUBLIC_API_URL,
+  import.meta.env.API_URL,
+]
+  .map((value) => value?.trim())
+  .find(Boolean);
 
 // 🔹 Fallbacks:
 //    - entorno local: usa el backend en localhost:4000
 //    - producción sin variable: asume mismo dominio del frontend (ruta /api)
-const defaultBaseUrl =
-  typeof window !== "undefined" && window.location.hostname === "localhost"
-    ? "http://localhost:4000/api"
-    : "/api";
+const isLocalhost =
+  typeof window !== "undefined" && window.location.hostname === "localhost";
+
+const defaultBaseUrl = isLocalhost ? "http://localhost:4000/api" : "/api";
 
 const api = axios.create({
   baseURL: envBaseUrl || defaultBaseUrl,

--- a/fractal-challenge/frontend/src/pages/ProductsPage.jsx
+++ b/fractal-challenge/frontend/src/pages/ProductsPage.jsx
@@ -1,26 +1,107 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import api from "../api";
+
+const formatCurrency = (value) => {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+  return numeric.toLocaleString("es-PE", {
+    style: "currency",
+    currency: "PEN",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
 
 export default function ProductsPage() {
   const [products, setProducts] = useState([]);
   const [name, setName] = useState("");
   const [price, setPrice] = useState("");
+  const [feedback, setFeedback] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const feedbackTimeoutRef = useRef();
 
-  useEffect(() => {
-    const fetchProducts = async () => {
-      const res = await api.get("/products");
-      setProducts(res.data);
-    };
-    fetchProducts();
+  const scheduleFeedbackClear = useCallback(() => {
+    if (feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current);
+    }
+    feedbackTimeoutRef.current = setTimeout(() => {
+      setFeedback(null);
+      feedbackTimeoutRef.current = undefined;
+    }, 4000);
   }, []);
 
-  const addProduct = async () => {
-    if (!name || !price) return;
-    await api.post("/products", { name, price });
-    setName("");
-    setPrice("");
-    const res = await api.get("/products");
-    setProducts(res.data);
+  const loadProducts = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await api.get("/products");
+      setProducts(res.data);
+    } catch (error) {
+      console.error("Error al cargar productos", error);
+      setFeedback({
+        type: "error",
+        message:
+          "No se pudieron cargar los productos. Verifica la conexión con el backend.",
+      });
+      scheduleFeedbackClear();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scheduleFeedbackClear]);
+
+  useEffect(() => {
+    loadProducts();
+  }, [loadProducts]);
+
+  useEffect(
+    () => () => {
+      if (feedbackTimeoutRef.current) {
+        clearTimeout(feedbackTimeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    const parsedPrice = Number(price);
+
+    if (!trimmedName) {
+      setFeedback({ type: "error", message: "Ingresa un nombre para el producto." });
+      scheduleFeedbackClear();
+      return;
+    }
+
+    if (!Number.isFinite(parsedPrice) || parsedPrice <= 0) {
+      setFeedback({
+        type: "error",
+        message: "El precio debe ser un número mayor que cero.",
+      });
+      scheduleFeedbackClear();
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await api.post("/products", { name: trimmedName, price: parsedPrice });
+      setFeedback({ type: "success", message: "Producto agregado correctamente." });
+      setName("");
+      setPrice("");
+      await loadProducts();
+    } catch (error) {
+      const apiMessage = error?.response?.data?.error;
+      setFeedback({
+        type: "error",
+        message: apiMessage || "No se pudo agregar el producto. Intenta nuevamente.",
+      });
+    } finally {
+      setIsSubmitting(false);
+      scheduleFeedbackClear();
+    }
   };
 
   return (
@@ -30,40 +111,70 @@ export default function ProductsPage() {
           🛒 Gestión de Productos
         </h1>
 
-        <div className="flex gap-2 mb-6">
-          <input
-            type="text"
-            placeholder="Nombre del producto"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="flex-1 px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
-          />
-          <input
-            type="number"
-            placeholder="Precio"
-            value={price}
-            onChange={(e) => setPrice(e.target.value)}
-            className="w-28 px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
-          />
-          <button
-            onClick={addProduct}
-            className="px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-semibold"
+        {feedback && (
+          <div
+            className={`mb-6 rounded-lg border px-4 py-3 text-sm font-medium ${
+              feedback.type === "success"
+                ? "border-green-500 bg-green-500/10 text-green-200"
+                : "border-red-500 bg-red-500/10 text-red-200"
+            }`}
+            role="status"
           >
-            Agregar
-          </button>
-        </div>
+            {feedback.message}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 mb-6">
+          <div className="flex gap-2 flex-wrap sm:flex-nowrap">
+            <input
+              type="text"
+              placeholder="Nombre del producto"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="flex-1 min-w-[12rem] px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
+            />
+            <input
+              type="number"
+              placeholder="Precio"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              min="0"
+              step="0.01"
+              className="w-full sm:w-32 px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
+            />
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className={`px-4 py-2 rounded text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-green-400 ${
+                isSubmitting
+                  ? "bg-green-700/60 cursor-not-allowed"
+                  : "bg-green-600 hover:bg-green-700"
+              }`}
+            >
+              {isSubmitting ? "Guardando..." : "Agregar"}
+            </button>
+          </div>
+        </form>
 
         <h2 className="text-xl font-semibold mb-4">📋 Lista de Productos</h2>
-        <ul className="space-y-2">
-          {products.map((p) => (
-            <li
-              key={p.id}
-              className="p-3 bg-gray-700 rounded flex justify-between items-center"
-            >
-              <span>{p.name} - ${p.price}</span>
-            </li>
-          ))}
-        </ul>
+
+        {isLoading ? (
+          <p className="text-gray-300">Cargando productos...</p>
+        ) : products.length === 0 ? (
+          <p className="text-gray-400">Aún no hay productos registrados.</p>
+        ) : (
+          <ul className="space-y-2">
+            {products.map((p) => (
+              <li
+                key={p.id}
+                className="p-3 bg-gray-700 rounded flex justify-between items-center"
+              >
+                <span className="font-medium">{p.name}</span>
+                <span className="text-gray-200">{formatCurrency(p.price)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow the frontend API client to read the backend base URL from `VITE_API_URL` with sensible fallbacks for local and production builds
- add deployment notes and a sample `.env` file documenting how to configure the frontend
- update the PostCSS configuration to use the Tailwind CSS v4 plugin so production builds succeed
- switch the SPA to use a hash-based router so Vercel serves all pages correctly
- document backend environment variables and provide a sample `.env` file for configuring cloud MySQL credentials
- extend the backend MySQL pool so it accepts connection strings, SSL requirements and pool size through environment variables for cloud deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9990352f4832fbbad023a1e324a2d