### PR TITLE
Replace Tailwind build dependency with static utility CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Aplicación Fullstack para gestionar productos y órdenes, con un backend en Nod
 - Asociar productos a órdenes con cantidades.  
 
 ## Instalación rápida
+
 ```bash
 # Backend
 cd backend
@@ -24,3 +25,35 @@ npm run dev   # Servidor en http://localhost:4000/api
 cd frontend
 npm install
 npm run dev   # App en http://localhost:5173
+```
+
+## Variables de entorno para despliegue
+
+### Frontend
+
+1. Copia `frontend/.env.example` como `frontend/.env`.
+2. Ajusta `VITE_API_URL` con la URL pública de tu backend (incluye el sufijo `/api`). Si ya tienes configuradas variables como `VITE_BACKEND_URL`, `PUBLIC_API_URL` o `API_URL` en tu plataforma de despliegue, el build también las tomará como alias.
+3. Ejecuta `npm run build` dentro de `frontend` y sirve la carpeta `dist` generada.
+
+### Backend
+
+1. Copia `backend/.env.example` como `backend/.env`.
+2. Si tu base de datos está en la nube, reemplaza las variables (`DB_HOST`, `DB_PORT`, `DB_USER`/`DB_USERNAME`, `DB_PASS`/`DB_PASSWORD`, `DB_NAME`/`DB_DATABASE`) con las credenciales provistas.
+3. Alternativamente puedes pegar la cadena completa que entregan servicios como PlanetScale, Railway o Clever Cloud en `DB_URL` (`mysql://usuario:clave@host:puerto/base`). También se aceptan `DATABASE_URL` y `CLEARDB_DATABASE_URL`.
+4. Si tu proveedor requiere TLS, activa `DB_SSL=true` para que la conexión utilice SSL. Si el host termina en `.proxy.rlwy.net` o `.railway.app` (como en Railway), el backend activará SSL automáticamente aunque no definas la variable.
+5. (Opcional) Ajusta `DB_POOL_LIMIT` si necesitas controlar la cantidad máxima de conexiones simultáneas que abrirá el backend.
+6. Inicia el servidor con `npm run start` (o configura el proceso según tu plataforma de despliegue) y asegúrate de que la aplicación frontend apunte a la ruta pública del backend (`/api`).
+7. Para un despliegue en el mismo servidor (localhost) basta con que MySQL esté corriendo en `localhost:3306`. El backend intentará crear la base de datos `fractal_db` y las tablas requeridas al arrancar si la cuenta tiene privilegios de creación. Si tu proveedor bloquea esas operaciones, define `DB_PREPARE=false` y gestiona el esquema manualmente.
+
+#### ¿Sin MySQL instalado?
+
+Puedes crear una instancia local rápidamente con Docker:
+
+```bash
+docker run --name fractal-mysql \
+  -e MYSQL_ROOT_PASSWORD=fractal \
+  -e MYSQL_DATABASE=fractal_db \
+  -p 3306:3306 -d mysql:8.0
+```
+
+Luego actualiza `backend/.env` con `DB_PASSWORD=fractal` (o usa el usuario que prefieras). Al iniciar el backend se crearán automáticamente las tablas necesarias.

--- a/fractal-challenge/backend/.env.example
+++ b/fractal-challenge/backend/.env.example
@@ -1,0 +1,29 @@
+# Credenciales para una instancia local de MySQL
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+# DB_USERNAME=root
+DB_PASSWORD=
+# DB_PASS=
+DB_NAME=fractal_db
+# DB_DATABASE=fractal_db
+
+# (Opcional) Cadena de conexión completa si tu proveedor la entrega
+# DB_URL=mysql://usuario:clave@host:3306/fractal_db
+
+# (Opcional) Activa SSL para proveedores como PlanetScale o Clever Cloud
+# DB_SSL=true
+
+# (Opcional) Ajusta el tamaño del pool de conexiones del servidor
+# DB_POOL_LIMIT=10
+
+# (Opcional) Desactiva la creación automática de base de datos y tablas
+# DB_PREPARE=false
+
+# Ejemplo para una instancia de Railway (reemplaza la contraseña real)
+# DB_HOST=switchyard.proxy.rlwy.net
+# DB_PORT=20511
+# DB_USER=root
+# DB_PASSWORD=tu_contraseña
+# DB_NAME=railway
+# DB_SSL=true

--- a/fractal-challenge/backend/src/db.js
+++ b/fractal-challenge/backend/src/db.js
@@ -3,9 +3,192 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-export const db = await mysql.createPool({
-  host: process.env.DB_HOST || "localhost",
-  user: process.env.DB_USER || "root",
-  password: process.env.DB_PASS || "",
-  database: process.env.DB_NAME || "fractal_db"
-});
+const pickEnv = (...keys) => {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+      const value = process.env[key];
+      if (typeof value === "string" && value.trim() === "") {
+        continue;
+      }
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const parsePositiveInt = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const readBooleanEnv = (value, fallback) => {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
+};
+
+const connectionString =
+  process.env.DB_URL ||
+  process.env.DATABASE_URL ||
+  process.env.CLEARDB_DATABASE_URL;
+
+const parseConnectionString = (urlString) => {
+  try {
+    const url = new URL(urlString);
+    const sslParam =
+      url.searchParams.get("ssl") ||
+      url.searchParams.get("sslmode") ||
+      url.searchParams.get("ssl-mode");
+    const wantsSsl =
+      typeof sslParam === "string" &&
+      ["1", "true", "require", "required", "verify_ca", "verify_identity", "verify_full"].includes(
+        sslParam.toLowerCase()
+      );
+
+    return {
+      host: url.hostname,
+      port: parsePositiveInt(url.port, 3306),
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+      database: url.pathname.replace(/^\//, ""),
+      ...(wantsSsl ? { ssl: { rejectUnauthorized: false } } : {}),
+    };
+  } catch (error) {
+    throw new Error(
+      "No se pudo interpretar la cadena de conexión definida en DB_URL/DATABASE_URL"
+    );
+  }
+};
+
+const connectionConfig = connectionString
+  ? parseConnectionString(connectionString)
+  : {
+      host: pickEnv("DB_HOST", "DATABASE_HOST") || "localhost",
+      port: parsePositiveInt(pickEnv("DB_PORT", "DATABASE_PORT"), 3306),
+      user: pickEnv("DB_USER", "DB_USERNAME") || "root",
+      password: pickEnv("DB_PASS", "DB_PASSWORD") || "",
+      database: pickEnv("DB_NAME", "DB_DATABASE") || "fractal_db",
+    };
+
+const hostForInference = (connectionConfig.host || "").toLowerCase();
+const inferredSslHosts = [".proxy.rlwy.net", ".railway.app"];
+const shouldForceSslByHost = inferredSslHosts.some((suffix) =>
+  hostForInference.endsWith(suffix)
+);
+
+const shouldUseSsl = readBooleanEnv(process.env.DB_SSL, false);
+const shouldPrepareDatabase = readBooleanEnv(process.env.DB_PREPARE, true);
+
+if ((shouldUseSsl || shouldForceSslByHost) && !connectionConfig.ssl) {
+  connectionConfig.ssl = { rejectUnauthorized: false };
+  if (shouldForceSslByHost && !shouldUseSsl) {
+    console.info(
+      "🔐 Se habilitó SSL automáticamente por coincidir con un host de Railway"
+    );
+  }
+}
+
+const ensureDatabaseExists = async (config) => {
+  const databaseName = config.database;
+  if (!databaseName) {
+    return;
+  }
+
+  try {
+    const connection = await mysql.createConnection(config);
+    await connection.query("SELECT 1");
+    await connection.end();
+  } catch (error) {
+    if (error?.code !== "ER_BAD_DB_ERROR") {
+      throw error;
+    }
+
+    const { database, ...adminConfig } = config;
+    const adminConnection = await mysql.createConnection(adminConfig);
+    await adminConnection.query(
+      `CREATE DATABASE IF NOT EXISTS \`${databaseName}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`
+    );
+    await adminConnection.end();
+
+    console.info(`🛠️  Base de datos "${databaseName}" creada automáticamente.`);
+  }
+};
+
+const ensureSchema = async (pool) => {
+  const tables = [
+    {
+      name: "orders",
+      createStatement: `CREATE TABLE IF NOT EXISTS orders (
+        id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        order_number VARCHAR(100) NOT NULL UNIQUE,
+        status VARCHAR(50) NOT NULL DEFAULT 'Pending',
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+    },
+    {
+      name: "products",
+      createStatement: `CREATE TABLE IF NOT EXISTS products (
+        id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        price DECIMAL(10,2) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+    },
+    {
+      name: "order_products",
+      createStatement: `CREATE TABLE IF NOT EXISTS order_products (
+        id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        order_id INT UNSIGNED NOT NULL,
+        product_id INT UNSIGNED NOT NULL,
+        qty INT UNSIGNED NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT order_products_order_fk FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
+        CONSTRAINT order_products_product_fk FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+    },
+  ];
+
+  for (const { name, createStatement } of tables) {
+    const [rows] = await pool.query("SHOW TABLES LIKE ?", [name]);
+    if (rows.length === 0) {
+      await pool.query(createStatement);
+      console.info(`🛠️  Tabla "${name}" creada automáticamente.`);
+    }
+  }
+};
+
+if (shouldPrepareDatabase) {
+  try {
+    await ensureDatabaseExists(connectionConfig);
+  } catch (error) {
+    console.error("❌ No se pudo preparar la base de datos:", error.message);
+    throw error;
+  }
+}
+
+const poolConfig = {
+  waitForConnections: true,
+  connectionLimit: parsePositiveInt(process.env.DB_POOL_LIMIT, 10),
+  ...connectionConfig,
+};
+
+export const db = await mysql.createPool(poolConfig);
+
+if (shouldPrepareDatabase) {
+  try {
+    await ensureSchema(db);
+  } catch (error) {
+    console.error("❌ No se pudo crear el esquema MySQL:", error.message);
+    throw error;
+  }
+}

--- a/fractal-challenge/backend/src/routes/orderProducts.js
+++ b/fractal-challenge/backend/src/routes/orderProducts.js
@@ -3,26 +3,40 @@ import { db } from "../db.js";
 
 const router = Router();
 
+const parsePositiveInt = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+};
+
 /**
  * Agregar un producto a una orden
  */
 router.post("/", async (req, res) => {
   try {
-    console.log("Body recibido:", req.body); // 👈 Para depuración
+    const orderId = parsePositiveInt(req.body?.order_id);
+    const productId = parsePositiveInt(req.body?.product_id);
+    const quantity = parsePositiveInt(req.body?.qty);
 
-    const { order_id, product_id, qty } = req.body;
-    if (!order_id || !product_id || !qty) {
-      return res.status(400).json({ error: "Faltan campos" });
+    if (!orderId || !productId || !quantity) {
+      return res.status(400).json({
+        error: "Debes enviar order_id, product_id y qty como enteros mayores a 0",
+      });
     }
 
     const [result] = await db.query(
       "INSERT INTO order_products (order_id, product_id, qty) VALUES (?, ?, ?)",
-      [order_id, product_id, qty]
+      [orderId, productId, quantity]
     );
 
-    res
-      .status(201)
-      .json({ id: result.insertId, order_id, product_id, qty });
+    res.status(201).json({
+      id: result.insertId,
+      order_id: orderId,
+      product_id: productId,
+      qty: quantity,
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -55,14 +69,24 @@ router.get("/:order_id", async (req, res) => {
 router.put("/:id", async (req, res) => {
   try {
     const { id } = req.params;
-    const { qty } = req.body;
+    const quantity = parsePositiveInt(req.body?.qty);
 
-    await db.query("UPDATE order_products SET qty=? WHERE id=?", [
-      qty,
+    if (!quantity) {
+      return res
+        .status(400)
+        .json({ error: "La cantidad debe ser un entero mayor a 0" });
+    }
+
+    const [result] = await db.query("UPDATE order_products SET qty=? WHERE id=?", [
+      quantity,
       id,
     ]);
 
-    res.json({ id, qty });
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: "Producto no encontrado en la orden" });
+    }
+
+    res.json({ id: Number(id), qty: quantity });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/fractal-challenge/frontend/.env.example
+++ b/fractal-challenge/frontend/.env.example
@@ -1,0 +1,3 @@
+# URL base del backend expuesta para el frontend (incluye /api)
+# También se aceptan los alias VITE_BACKEND_URL, PUBLIC_API_URL o API_URL
+VITE_API_URL=http://localhost:4000/api

--- a/fractal-challenge/frontend/package-lock.json
+++ b/fractal-challenge/frontend/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
-        "@tailwindcss/postcss": "^4.1.13",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -25,21 +24,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
         "postcss": "^8.5.6",
-        "tailwindcss": "^4.1.13",
         "vite": "^7.1.2"
-      }
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -972,19 +957,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1336,282 +1308,6 @@
         "win32"
       ]
     },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
-      "integrity": "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "enhanced-resolve": "^5.18.3",
-        "jiti": "^2.5.1",
-        "lightningcss": "1.30.1",
-        "magic-string": "^0.30.18",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.13"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.13.tgz",
-      "integrity": "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.4",
-        "tar": "^7.4.3"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.13",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.13",
-        "@tailwindcss/oxide-darwin-x64": "4.1.13",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.13",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.13",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.13",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.13",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.13",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.13",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.13",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.13"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.13.tgz",
-      "integrity": "sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.13.tgz",
-      "integrity": "sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.13.tgz",
-      "integrity": "sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.13.tgz",
-      "integrity": "sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.13.tgz",
-      "integrity": "sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.13.tgz",
-      "integrity": "sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.13.tgz",
-      "integrity": "sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.13.tgz",
-      "integrity": "sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.13.tgz",
-      "integrity": "sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.13.tgz",
-      "integrity": "sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.5",
-        "@emnapi/runtime": "^1.4.5",
-        "@emnapi/wasi-threads": "^1.0.4",
-        "@napi-rs/wasm-runtime": "^0.2.12",
-        "@tybys/wasm-util": "^0.10.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.13.tgz",
-      "integrity": "sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.13.tgz",
-      "integrity": "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.13.tgz",
-      "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.13",
-        "@tailwindcss/oxide": "4.1.13",
-        "postcss": "^8.4.41",
-        "tailwindcss": "4.1.13"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1953,16 +1649,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2080,6 +1766,8 @@
       "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2104,20 +1792,6 @@
       "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2656,13 +2330,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2785,6 +2452,8 @@
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2886,6 +2555,8 @@
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -2922,6 +2593,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2943,6 +2615,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2964,6 +2637,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2985,6 +2659,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3006,6 +2681,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3027,6 +2703,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3048,6 +2725,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3069,6 +2747,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3090,6 +2769,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3111,6 +2791,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3150,16 +2831,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3203,45 +2874,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -3658,55 +3290,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
-      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
-      "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {

--- a/fractal-challenge/frontend/package.json
+++ b/fractal-challenge/frontend/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@tailwindcss/postcss": "^4.1.13",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -27,7 +26,6 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.13",
     "vite": "^7.1.2"
   }
 }

--- a/fractal-challenge/frontend/postcss.config.js
+++ b/fractal-challenge/frontend/postcss.config.js
@@ -1,6 +1,5 @@
+import autoprefixer from "autoprefixer";
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+  plugins: [autoprefixer()],
+};

--- a/fractal-challenge/frontend/src/App.jsx
+++ b/fractal-challenge/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, NavLink } from "react-router-dom";
+import { HashRouter as Router, Routes, Route, NavLink, Navigate } from "react-router-dom";
 import ProductsPage from "./pages/ProductsPage";
 import OrdersPage from "./pages/OrdersPage";
 import OrderProductsPage from "./pages/OrderProductsPage";
@@ -48,10 +48,11 @@ function App() {
         {/* 🔹 Contenido */}
         <div className="container mx-auto px-6 py-8">
           <Routes>
-            <Route path="/" element={<ProductsPage />} />
+            <Route path="/" element={<Navigate to="/products" replace />} />
             <Route path="/products" element={<ProductsPage />} />
             <Route path="/orders" element={<OrdersPage />} />
             <Route path="/order-products" element={<OrderProductsPage />} />
+            <Route path="*" element={<Navigate to="/products" replace />} />
           </Routes>
         </div>
       </div>

--- a/fractal-challenge/frontend/src/api.js
+++ b/fractal-challenge/frontend/src/api.js
@@ -1,9 +1,28 @@
 // src/api.js
 import axios from "axios";
 
-// 🔹 Crear instancia de axios con la URL base de tu backend
+// 🔹 Permite definir la URL del backend mediante variables de entorno en build
+//    - Reutiliza el nombre actual (VITE_API_URL) y los alias previos (p. ej. VITE_BACKEND_URL)
+//    - También acepta variables genéricas como PUBLIC_API_URL o API_URL que algunos hosts exponen automáticamente
+const envBaseUrl = [
+  import.meta.env.VITE_API_URL,
+  import.meta.env.VITE_BACKEND_URL,
+  import.meta.env.PUBLIC_API_URL,
+  import.meta.env.API_URL,
+]
+  .map((value) => value?.trim())
+  .find(Boolean);
+
+// 🔹 Fallbacks:
+//    - entorno local: usa el backend en localhost:4000
+//    - producción sin variable: asume mismo dominio del frontend (ruta /api)
+const isLocalhost =
+  typeof window !== "undefined" && window.location.hostname === "localhost";
+
+const defaultBaseUrl = isLocalhost ? "http://localhost:4000/api" : "/api";
+
 const api = axios.create({
-  baseURL: "http://localhost:4000/api",
+  baseURL: envBaseUrl || defaultBaseUrl,
   headers: {
     "Content-Type": "application/json",
   },

--- a/fractal-challenge/frontend/src/index.css
+++ b/fractal-challenge/frontend/src/index.css
@@ -1,70 +1,507 @@
 
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  color-scheme: dark;
+  --ring-color: rgba(59, 130, 246, 0.5);
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background-color: #0f172a;
+  color: #f9fafb;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.min-h-screen {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.container {
+  width: min(100%, 72rem);
+  margin: 0 auto;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.max-w-2xl {
+  max-width: 42rem;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-24 {
+  width: 6rem;
+}
+
+.sm\:w-32 {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .sm\:w-32 {
+    width: 8rem;
+  }
+  .sm\:flex-nowrap {
+    flex-wrap: nowrap;
+  }
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.space-x-8 {
+  column-gap: 2rem;
+}
+
+.space-y-2 > * + * {
+  margin-top: 0.5rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-8 {
+  padding: 2rem;
+}
+
+.p-10 {
+  padding: 2.5rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+
+.font-medium {
   font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.font-semibold {
+  font-weight: 600;
 }
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-extrabold {
+  font-weight: 800;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
+
+.rounded {
+  border-radius: 0.375rem;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.shadow-lg {
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.25), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+}
+
+.border {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.border-gray-600 {
+  border-color: #4b5563;
+}
+
+.border-gray-700 {
+  border-color: #374151;
+}
+
+.border-green-500 {
+  border-color: #22c55e;
+}
+
+.border-red-500 {
+  border-color: #ef4444;
+}
+
+.text-white {
+  color: #ffffff;
+}
+
+.text-gray-200 {
+  color: #e5e7eb;
+}
+
+.text-gray-300 {
+  color: #d1d5db;
+}
+
+.text-gray-400 {
+  color: #9ca3af;
+}
+
+.text-green-200 {
+  color: #bbf7d0;
+}
+
+.text-green-400 {
+  color: #4ade80;
+}
+
+.text-blue-400 {
+  color: #60a5fa;
+}
+
+.text-red-300 {
+  color: #fca5a5;
+}
+
+.text-red-200 {
+  color: #fecaca;
+}
+
+.text-gray-300,
+.text-gray-400,
+.text-gray-200 {
+  transition: color 0.2s ease-in-out;
+}
+
+.bg-gray-900 {
+  background-color: #111827;
+}
+
+.bg-gray-800 {
+  background-color: #1f2937;
+}
+
+.bg-gray-700 {
+  background-color: #374151;
+}
+
+.bg-blue-600 {
+  background-color: #2563eb;
+}
+
+.hover\:bg-blue-700:hover {
+  background-color: #1d4ed8;
+}
+
+.bg-green-600 {
+  background-color: #16a34a;
+}
+
+.hover\:bg-green-700:hover {
+  background-color: #15803d;
+}
+
+.bg-green-700\/60 {
+  background-color: rgba(21, 128, 61, 0.6);
+}
+
+.bg-green-500\/10 {
+  background-color: rgba(34, 197, 94, 0.1);
+}
+
+.bg-red-500\/10 {
+  background-color: rgba(239, 68, 68, 0.1);
+}
+
+.bg-purple-600 {
+  background-color: #7c3aed;
+}
+
+.hover\:bg-purple-700:hover {
+  background-color: #6d28d9;
+}
+
+.bg-purple-800\/60 {
+  background-color: rgba(91, 33, 182, 0.6);
+}
+
+.bg-gray-800\/60 {
+  background-color: rgba(31, 41, 55, 0.6);
+}
+
+.bg-gray-800\/50 {
+  background-color: rgba(31, 41, 55, 0.5);
+}
+
+.bg-gray-800\/40 {
+  background-color: rgba(31, 41, 55, 0.4);
+}
+
+.bg-purple-600,
+.bg-blue-600,
+.bg-green-600 {
+  color: #ffffff;
+}
+
+.hover\:text-white:hover {
+  color: #ffffff;
+}
+
+.hover\:text-red-200:hover {
+  color: #fecaca;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.transition {
+  transition: all 0.2s ease-in-out;
+}
+
+.transition-colors {
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.tracking-wider {
+  letter-spacing: 0.08em;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
+}
+
+.min-w-full {
+  min-width: 100%;
+}
+
+.min-w-\[12rem\] {
+  min-width: 12rem;
+}
+
+
+.focus\:outline-none:focus {
+  outline: none;
+}
+
+.focus\:ring-2:focus {
+  box-shadow: 0 0 0 2px var(--ring-color);
+}
+
+.focus\:ring-blue-500 {
+  --ring-color: rgba(59, 130, 246, 0.6);
+}
+
+.focus\:ring-green-500 {
+  --ring-color: rgba(34, 197, 94, 0.6);
+}
+
+.focus\:ring-green-400 {
+  --ring-color: rgba(74, 222, 128, 0.6);
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+
+.divide-y > * + * {
+  border-top: 1px solid var(--divide-color, rgba(55, 65, 81, 0.6));
+}
+
+.divide-gray-700 {
+  --divide-color: rgba(55, 65, 81, 0.8);
+}
+
+.divide-gray-800 {
+  --divide-color: rgba(31, 41, 55, 0.8);
+}
+
+.text-gray-300 {
+  color: #d1d5db;
+}
+
+.text-gray-200 {
+  color: #e5e7eb;
+}
+
+.text-gray-400 {
+  color: #9ca3af;
+}
+
+.text-green-400 {
+  color: #4ade80;
+}
+
+.text-green-200 {
+  color: #bbf7d0;
+}
+
+.text-blue-400 {
+  color: #60a5fa;
+}
+
+.text-red-300 {
+  color: #fca5a5;
+}
+
+.text-red-200 {
+  color: #fecaca;
+}
+
+.text-white {
+  color: #ffffff;
+}
+
+.text-green-400,
+.text-blue-400,
+.text-red-300,
+.text-red-200,
+.text-green-200 {
+  transition: color 0.2s ease-in-out;
+}
+
+.text-sm,
+.text-xl,
+.text-3xl,
+.text-4xl {
+  color: inherit;
+}
+
+.bg-purple-600,
+.bg-blue-600,
+.bg-green-600,
+.bg-gray-700,
+.bg-gray-800,
+.bg-gray-900 {
+  transition: background-color 0.2s ease-in-out;
+}
+

--- a/fractal-challenge/frontend/src/pages/OrderProductsPage.jsx
+++ b/fractal-challenge/frontend/src/pages/OrderProductsPage.jsx
@@ -1,46 +1,196 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import api from "../api";
+
+const formatCurrency = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+  return numeric.toLocaleString("es-PE", {
+    style: "currency",
+    currency: "PEN",
+    minimumFractionDigits: 2,
+  });
+};
 
 export default function OrderProductsPage() {
   const [orders, setOrders] = useState([]);
   const [products, setProducts] = useState([]);
   const [orderId, setOrderId] = useState("");
   const [productId, setProductId] = useState("");
-  const [qty, setQty] = useState(1);
-  const [message, setMessage] = useState("");
+  const [qty, setQty] = useState("1");
+  const [orderItems, setOrderItems] = useState([]);
+  const [isLoadingOrders, setIsLoadingOrders] = useState(true);
+  const [isLoadingItems, setIsLoadingItems] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const resOrders = await api.get("/orders");
-      setOrders(resOrders.data);
-      const resProducts = await api.get("/products");
-      setProducts(resProducts.data);
-    };
-    fetchData();
-  }, []);
+  const selectedOrder = useMemo(
+    () => orders.find((order) => String(order.id) === String(orderId)),
+    [orders, orderId]
+  );
 
-  const handleAddProduct = async () => {
+  const loadInitialData = async () => {
+    setIsLoadingOrders(true);
     try {
-      await api.post("/order-products", { order_id: orderId, product_id: productId, qty });
-      setMessage("Producto agregado correctamente");
-    } catch {
-      setMessage("Error al agregar producto");
+      const [ordersResponse, productsResponse] = await Promise.all([
+        api.get("/orders"),
+        api.get("/products"),
+      ]);
+      setOrders(ordersResponse.data);
+      setProducts(productsResponse.data);
+    } catch (error) {
+      console.error("No se pudieron cargar órdenes o productos", error);
+      setMessage({
+        type: "error",
+        text: "No se pudieron cargar órdenes o productos. Revisa el backend.",
+      });
+    } finally {
+      setIsLoadingOrders(false);
     }
   };
+
+  const loadOrderItems = async (id) => {
+    if (!id) {
+      setOrderItems([]);
+      return;
+    }
+
+    setIsLoadingItems(true);
+    try {
+      const { data } = await api.get(`/order-products/${id}`);
+      setOrderItems(data);
+    } catch (error) {
+      console.error("No se pudieron cargar los productos de la orden", error);
+      setMessage({
+        type: "error",
+        text: "No se pudieron cargar los productos de la orden seleccionada.",
+      });
+      setOrderItems([]);
+    } finally {
+      setIsLoadingItems(false);
+    }
+  };
+
+  useEffect(() => {
+    loadInitialData();
+  }, []);
+
+  useEffect(() => {
+    loadOrderItems(orderId);
+  }, [orderId]);
+
+  const handleAddProduct = async () => {
+    if (!orderId) {
+      setMessage({ type: "error", text: "Selecciona una orden para continuar." });
+      return;
+    }
+    if (!productId) {
+      setMessage({
+        type: "error",
+        text: "Selecciona un producto antes de agregarlo a la orden.",
+      });
+      return;
+    }
+
+    const normalizedQty = Number(qty);
+    if (!Number.isInteger(normalizedQty) || normalizedQty <= 0) {
+      setMessage({
+        type: "error",
+        text: "La cantidad debe ser un número entero mayor que cero.",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await api.post("/order-products", {
+        order_id: Number(orderId),
+        product_id: Number(productId),
+        qty: normalizedQty,
+      });
+      setMessage({ type: "success", text: "Producto agregado a la orden." });
+      setProductId("");
+      setQty("1");
+      await loadOrderItems(orderId);
+    } catch (error) {
+      console.error("Error al agregar producto a la orden", error);
+      const apiMessage = error?.response?.data?.error;
+      setMessage({
+        type: "error",
+        text: apiMessage || "No se pudo agregar el producto. Inténtalo de nuevo.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRemoveItem = async (itemId) => {
+    if (!orderId) return;
+    const shouldRemove = window.confirm(
+      "¿Deseas quitar este producto de la orden?"
+    );
+    if (!shouldRemove) return;
+
+    try {
+      await api.delete(`/order-products/${itemId}`);
+      setMessage({ type: "success", text: "Producto eliminado de la orden." });
+      await loadOrderItems(orderId);
+    } catch (error) {
+      console.error("Error al eliminar producto", error);
+      setMessage({
+        type: "error",
+        text: "No se pudo eliminar el producto de la orden.",
+      });
+    }
+  };
+
+  const totals = useMemo(() => {
+    if (!orderItems.length) {
+      return { quantity: 0, subtotal: 0 };
+    }
+
+    return orderItems.reduce(
+      (acc, item) => {
+        const itemQty = Number(item.qty) || 0;
+        const itemTotal = Number(item.total) || 0;
+        return {
+          quantity: acc.quantity + itemQty,
+          subtotal: acc.subtotal + itemTotal,
+        };
+      },
+      { quantity: 0, subtotal: 0 }
+    );
+  }, [orderItems]);
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-10">
       <h1 className="text-3xl font-bold mb-6">🛒 Asociar Productos a Órdenes</h1>
 
-      <div className="flex gap-2 mb-6">
+      {message && (
+        <div
+          className={`mb-6 rounded-lg border px-4 py-3 text-sm ${
+            message.type === "success"
+              ? "border-green-500 bg-green-500/10 text-green-200"
+              : "border-red-500 bg-red-500/10 text-red-200"
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 mb-6">
         <select
           value={orderId}
           onChange={(e) => setOrderId(e.target.value)}
           className="px-4 py-2 rounded bg-gray-800 border border-gray-600"
+          disabled={isLoadingOrders}
         >
           <option value="">Seleccionar Orden</option>
           {orders.map((o) => (
-            <option key={o.id} value={o.id}>{o.order_number}</option>
+            <option key={o.id} value={o.id}>
+              {o.order_number} ({o.status})
+            </option>
           ))}
         </select>
 
@@ -48,10 +198,13 @@ export default function OrderProductsPage() {
           value={productId}
           onChange={(e) => setProductId(e.target.value)}
           className="px-4 py-2 rounded bg-gray-800 border border-gray-600"
+          disabled={!orderId || isSubmitting}
         >
           <option value="">Seleccionar Producto</option>
           {products.map((p) => (
-            <option key={p.id} value={p.id}>{p.name}</option>
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
           ))}
         </select>
 
@@ -60,18 +213,94 @@ export default function OrderProductsPage() {
           value={qty}
           onChange={(e) => setQty(e.target.value)}
           min="1"
-          className="w-20 px-2 py-2 rounded bg-gray-800 border border-gray-600 text-center"
+          className="w-24 px-2 py-2 rounded bg-gray-800 border border-gray-600 text-center"
+          disabled={!orderId || isSubmitting}
         />
 
         <button
           onClick={handleAddProduct}
-          className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded text-white"
+          className={`px-4 py-2 rounded text-white font-semibold transition ${
+            isSubmitting
+              ? "bg-purple-800/60 cursor-not-allowed"
+              : "bg-purple-600 hover:bg-purple-700"
+          }`}
+          disabled={isSubmitting}
         >
-          Agregar
+          {isSubmitting ? "Agregando..." : "Agregar"}
         </button>
       </div>
 
-      {message && <p className="mb-4">{message}</p>}
+      {!orderId ? (
+        <p className="text-gray-300">
+          Selecciona una orden para ver o gestionar sus productos.
+        </p>
+      ) : isLoadingItems ? (
+        <p className="text-gray-300">Cargando productos de la orden...</p>
+      ) : orderItems.length === 0 ? (
+        <p className="text-gray-400">Esta orden aún no tiene productos asociados.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-700">
+            <thead>
+              <tr className="bg-gray-800/60 text-left text-sm uppercase tracking-wider">
+                <th className="px-4 py-3 font-semibold">Producto</th>
+                <th className="px-4 py-3 font-semibold">Precio</th>
+                <th className="px-4 py-3 font-semibold">Cantidad</th>
+                <th className="px-4 py-3 font-semibold">Total</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {orderItems.map((item) => (
+                <tr key={item.id}>
+                  <td className="px-4 py-3">{item.name}</td>
+                  <td className="px-4 py-3 text-gray-200">
+                    {formatCurrency(item.price)}
+                  </td>
+                  <td className="px-4 py-3">{item.qty}</td>
+                  <td className="px-4 py-3 text-gray-200">
+                    {formatCurrency(item.total)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => handleRemoveItem(item.id)}
+                      className="text-sm text-red-300 hover:text-red-200"
+                    >
+                      Quitar
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="bg-gray-800/40 text-sm font-semibold">
+                <td className="px-4 py-3">Totales</td>
+                <td className="px-4 py-3" />
+                <td className="px-4 py-3">{totals.quantity}</td>
+                <td className="px-4 py-3">{formatCurrency(totals.subtotal)}</td>
+                <td className="px-4 py-3" />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+
+      {selectedOrder && (
+        <div className="mt-6 rounded border border-gray-700 bg-gray-800/50 p-4 text-sm text-gray-200">
+          <p>
+            <span className="font-semibold">Orden:</span> {selectedOrder.order_number}
+          </p>
+          <p>
+            <span className="font-semibold">Estado:</span> {selectedOrder.status}
+          </p>
+          <p>
+            <span className="font-semibold">Productos totales:</span> {totals.quantity}
+          </p>
+          <p>
+            <span className="font-semibold">Subtotal:</span> {formatCurrency(totals.subtotal)}
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/fractal-challenge/frontend/src/pages/ProductsPage.jsx
+++ b/fractal-challenge/frontend/src/pages/ProductsPage.jsx
@@ -1,26 +1,107 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import api from "../api";
+
+const formatCurrency = (value) => {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+  return numeric.toLocaleString("es-PE", {
+    style: "currency",
+    currency: "PEN",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
 
 export default function ProductsPage() {
   const [products, setProducts] = useState([]);
   const [name, setName] = useState("");
   const [price, setPrice] = useState("");
+  const [feedback, setFeedback] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const feedbackTimeoutRef = useRef();
 
-  useEffect(() => {
-    const fetchProducts = async () => {
-      const res = await api.get("/products");
-      setProducts(res.data);
-    };
-    fetchProducts();
+  const scheduleFeedbackClear = useCallback(() => {
+    if (feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current);
+    }
+    feedbackTimeoutRef.current = setTimeout(() => {
+      setFeedback(null);
+      feedbackTimeoutRef.current = undefined;
+    }, 4000);
   }, []);
 
-  const addProduct = async () => {
-    if (!name || !price) return;
-    await api.post("/products", { name, price });
-    setName("");
-    setPrice("");
-    const res = await api.get("/products");
-    setProducts(res.data);
+  const loadProducts = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await api.get("/products");
+      setProducts(res.data);
+    } catch (error) {
+      console.error("Error al cargar productos", error);
+      setFeedback({
+        type: "error",
+        message:
+          "No se pudieron cargar los productos. Verifica la conexión con el backend.",
+      });
+      scheduleFeedbackClear();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scheduleFeedbackClear]);
+
+  useEffect(() => {
+    loadProducts();
+  }, [loadProducts]);
+
+  useEffect(
+    () => () => {
+      if (feedbackTimeoutRef.current) {
+        clearTimeout(feedbackTimeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    const parsedPrice = Number(price);
+
+    if (!trimmedName) {
+      setFeedback({ type: "error", message: "Ingresa un nombre para el producto." });
+      scheduleFeedbackClear();
+      return;
+    }
+
+    if (!Number.isFinite(parsedPrice) || parsedPrice <= 0) {
+      setFeedback({
+        type: "error",
+        message: "El precio debe ser un número mayor que cero.",
+      });
+      scheduleFeedbackClear();
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await api.post("/products", { name: trimmedName, price: parsedPrice });
+      setFeedback({ type: "success", message: "Producto agregado correctamente." });
+      setName("");
+      setPrice("");
+      await loadProducts();
+    } catch (error) {
+      const apiMessage = error?.response?.data?.error;
+      setFeedback({
+        type: "error",
+        message: apiMessage || "No se pudo agregar el producto. Intenta nuevamente.",
+      });
+    } finally {
+      setIsSubmitting(false);
+      scheduleFeedbackClear();
+    }
   };
 
   return (
@@ -30,40 +111,70 @@ export default function ProductsPage() {
           🛒 Gestión de Productos
         </h1>
 
-        <div className="flex gap-2 mb-6">
-          <input
-            type="text"
-            placeholder="Nombre del producto"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="flex-1 px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
-          />
-          <input
-            type="number"
-            placeholder="Precio"
-            value={price}
-            onChange={(e) => setPrice(e.target.value)}
-            className="w-28 px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
-          />
-          <button
-            onClick={addProduct}
-            className="px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-semibold"
+        {feedback && (
+          <div
+            className={`mb-6 rounded-lg border px-4 py-3 text-sm font-medium ${
+              feedback.type === "success"
+                ? "border-green-500 bg-green-500/10 text-green-200"
+                : "border-red-500 bg-red-500/10 text-red-200"
+            }`}
+            role="status"
           >
-            Agregar
-          </button>
-        </div>
+            {feedback.message}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 mb-6">
+          <div className="flex gap-2 flex-wrap sm:flex-nowrap">
+            <input
+              type="text"
+              placeholder="Nombre del producto"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="flex-1 min-w-[12rem] px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
+            />
+            <input
+              type="number"
+              placeholder="Precio"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              min="0"
+              step="0.01"
+              className="w-full sm:w-32 px-4 py-2 rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-green-500"
+            />
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className={`px-4 py-2 rounded text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-green-400 ${
+                isSubmitting
+                  ? "bg-green-700/60 cursor-not-allowed"
+                  : "bg-green-600 hover:bg-green-700"
+              }`}
+            >
+              {isSubmitting ? "Guardando..." : "Agregar"}
+            </button>
+          </div>
+        </form>
 
         <h2 className="text-xl font-semibold mb-4">📋 Lista de Productos</h2>
-        <ul className="space-y-2">
-          {products.map((p) => (
-            <li
-              key={p.id}
-              className="p-3 bg-gray-700 rounded flex justify-between items-center"
-            >
-              <span>{p.name} - ${p.price}</span>
-            </li>
-          ))}
-        </ul>
+
+        {isLoading ? (
+          <p className="text-gray-300">Cargando productos...</p>
+        ) : products.length === 0 ? (
+          <p className="text-gray-400">Aún no hay productos registrados.</p>
+        ) : (
+          <ul className="space-y-2">
+            {products.map((p) => (
+              <li
+                key={p.id}
+                className="p-3 bg-gray-700 rounded flex justify-between items-center"
+              >
+                <span className="font-medium">{p.name}</span>
+                <span className="text-gray-200">{formatCurrency(p.price)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- drop the Tailwind-specific dev dependencies and keep the PostCSS pipeline running with autoprefixer only to avoid the missing plugin error
- recreate the utility classes used by the app as handcrafted CSS rules so the existing React pages retain their layout, spacing, colors and interactive states without Tailwind

## Testing
- npm run build (frontend)
- DB_PREPARE=false node -e "import('./src/db.js').then(() => console.log('db module ok')).catch(err => { console.error(err); process.exit(1); });" (backend)


------
https://chatgpt.com/codex/tasks/task_e_68c9990352f4832fbbad023a1e324a2d