### PR TITLE
Replace Tailwind usage with handcrafted CSS styling

### DIFF
--- a/fractal-challenge/frontend/postcss.config.js
+++ b/fractal-challenge/frontend/postcss.config.js
@@ -1,6 +1,5 @@
-import tailwindcss from "@tailwindcss/postcss";
 import autoprefixer from "autoprefixer";
 
 export default {
-  plugins: [tailwindcss, autoprefixer],
+  plugins: [autoprefixer],
 };

--- a/fractal-challenge/frontend/src/components/ConfirmDialog.jsx
+++ b/fractal-challenge/frontend/src/components/ConfirmDialog.jsx
@@ -1,12 +1,12 @@
-﻿import Modal from "./Modal";
+import Modal from "./Modal";
 
-export default function ConfirmDialog({ open, title="Confirm", message, onCancel, onConfirm }) {
+export default function ConfirmDialog({ open, title = "Confirm", message, onCancel, onConfirm }) {
   return (
     <Modal open={open} title={title} onClose={onCancel}>
-      <p className="mb-4">{message}</p>
-      <div className="flex justify-end gap-2">
-        <button onClick={onCancel} className="px-3 py-1 rounded border">Cancel</button>
-        <button onClick={onConfirm} className="px-3 py-1 rounded bg-red-600 text-white">Confirm</button>
+      <p className="dialog__message">{message}</p>
+      <div className="modal__actions">
+        <button onClick={onCancel} className="btn btn--ghost">Cancel</button>
+        <button onClick={onConfirm} className="btn btn--danger">Confirm</button>
       </div>
     </Modal>
   );

--- a/fractal-challenge/frontend/src/components/Modal.jsx
+++ b/fractal-challenge/frontend/src/components/Modal.jsx
@@ -1,12 +1,14 @@
-﻿export default function Modal({ open, title, children, onClose }) {
+export default function Modal({ open, title, children, onClose }) {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative bg-white text-black w-full max-w-md rounded-xl shadow-xl p-4">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-lg font-semibold">{title}</h3>
-          <button onClick={onClose} className="px-2 py-1 rounded hover:bg-gray-100">✕</button>
+    <div className="modal">
+      <div className="modal__overlay" onClick={onClose} />
+      <div className="modal__panel">
+        <div className="modal__header">
+          <h3 className="modal__title">{title}</h3>
+          <button onClick={onClose} className="modal__close" aria-label="Close">
+            ✕
+          </button>
         </div>
         {children}
       </div>

--- a/fractal-challenge/frontend/src/components/Navbar.jsx
+++ b/fractal-challenge/frontend/src/components/Navbar.jsx
@@ -2,12 +2,11 @@ import { Link } from "react-router-dom";
 
 export default function Navbar() {
   return (
-    <nav className="bg-blue-600 text-white px-4 py-3">
-      <div className="max-w-5xl mx-auto flex gap-6">
-        <Link to="/my-orders" className="hover:underline">My Orders</Link>
-        <Link to="/add-order" className="hover:underline">Add Order</Link>
-        <Link to="/add-product">Agregar Producto</Link>
-
+    <nav className="navbar">
+      <div className="navbar__inner">
+        <Link to="/my-orders" className="navbar__link">My Orders</Link>
+        <Link to="/add-order" className="navbar__link">Add Order</Link>
+        <Link to="/add-product" className="navbar__link">Agregar Producto</Link>
       </div>
     </nav>
   );

--- a/fractal-challenge/frontend/src/components/ProductPickerModal.jsx
+++ b/fractal-challenge/frontend/src/components/ProductPickerModal.jsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Modal from "./Modal";
 
 export default function ProductPickerModal({
@@ -30,11 +30,11 @@ export default function ProductPickerModal({
 
   return (
     <Modal open={open} title="Add / Edit product" onClose={onClose}>
-      <div className="space-y-3">
-        <div>
-          <label className="block text-sm mb-1">Product</label>
+      <div className="stack stack--sm">
+        <div className="field">
+          <label>Product</label>
           <select
-            className="border rounded w-full p-2"
+            className="select"
             value={productId ?? ""}
             onChange={e => setProductId(Number(e.target.value))}
           >
@@ -43,19 +43,19 @@ export default function ProductPickerModal({
             ))}
           </select>
         </div>
-        <div>
-          <label className="block text-sm mb-1">Qty</label>
+        <div className="field">
+          <label>Qty</label>
           <input
             type="number"
             min="1"
-            className="border rounded w-full p-2"
+            className="input"
             value={qty}
             onChange={e => setQty(Number(e.target.value))}
           />
         </div>
-        <div className="flex justify-end gap-2">
-          <button onClick={onClose} className="px-3 py-1 rounded border">Cancel</button>
-          <button onClick={handleSave} className="px-3 py-1 rounded bg-blue-600 text-white">Save</button>
+        <div className="modal__actions">
+          <button onClick={onClose} className="btn btn--ghost">Cancel</button>
+          <button onClick={handleSave} className="btn btn--primary">Save</button>
         </div>
       </div>
     </Modal>

--- a/fractal-challenge/frontend/src/index.css
+++ b/fractal-challenge/frontend/src/index.css
@@ -1,77 +1,539 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-html, body, #root {
-  height: 100%;
-}
-
-
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #0f172a;
+  background-color: #e2e8f0;
+  color-scheme: light;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+* {
+  box-sizing: border-box;
 }
-a:hover {
-  color: #535bf2;
+
+html,
+body,
+#root {
+  height: 100%;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  background-color: #e2e8f0;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
+}
+
+a:hover {
+  text-decoration: underline;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+  font: inherit;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+button:disabled,
+button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+input,
+select,
+button,
+textarea {
+  font: inherit;
+}
+
+/* Navigation */
+.navbar {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(37, 99, 235, 0.25);
+}
+
+.navbar__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0 1.5rem;
+  height: 64px;
+}
+
+.navbar__link {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.navbar__link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+/* Layout */
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.page--narrow {
+  max-width: 960px;
+}
+
+.page--full-center {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+  padding: 2.5rem;
+}
+
+.card--compact {
+  padding: 2rem;
+}
+
+.card__title {
+  margin: 0 0 1.5rem;
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #0f172a;
+  text-align: center;
+}
+
+.page__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.page__title {
+  margin: 0;
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stack--sm {
+  gap: 0.75rem;
+}
+
+.stack--xs {
+  gap: 0.5rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+/* Forms */
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.input,
+.select {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.input--muted {
+  background-color: #f8fafc;
+  color: #475569;
+}
+
+.input--strong {
+  color: #047857;
+  font-weight: 700;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.9rem;
+  border: 1px solid transparent;
+  padding: 0.65rem 1.3rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.25);
+}
+
+.btn--primary:hover {
+  background: linear-gradient(135deg, #1d4ed8, #1e40af);
+}
+
+.btn--success {
+  background: linear-gradient(135deg, #16a34a, #15803d);
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(22, 163, 74, 0.25);
+}
+
+.btn--success:hover {
+  background: linear-gradient(135deg, #15803d, #166534);
+}
+
+.btn--danger {
+  background: linear-gradient(135deg, #dc2626, #b91c1c);
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(220, 38, 38, 0.2);
+}
+
+.btn--ghost {
+  background: #ffffff;
+  border-color: #cbd5f5;
+  color: #1f2937;
+}
+
+.btn--ghost:hover {
+  background: #f8fafc;
+}
+
+.btn--link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.btn--link:hover {
+  text-decoration: underline;
+  color: #1d4ed8;
+  transform: none;
+}
+
+.btn--danger-link {
+  color: #dc2626;
+}
+
+.btn--full {
+  width: 100%;
+}
+
+/* Tables */
+.table-container {
+  overflow-x: auto;
+  background: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.14);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.table thead {
+  background: #eef2ff;
+  color: #1e293b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.table th,
+.table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+}
+
+.table tbody tr {
+  border-top: 1px solid #e2e8f0;
+}
+
+.table tbody tr:nth-child(even) {
+  background: #f8fafc;
+}
+
+.table td.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.table__empty {
+  text-align: center;
+  padding: 1.5rem;
+  color: #94a3b8;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-success {
+  color: #047857;
+  font-weight: 700;
+}
+
+.text-muted {
+  color: #64748b;
+}
+
+.text-strong {
+  font-weight: 600;
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.modal__panel {
+  position: relative;
+  background: #ffffff;
+  color: #0f172a;
+  width: min(100%, 480px);
+  border-radius: 1.25rem;
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
+  padding: 2rem;
+  z-index: 10;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.modal__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  border-radius: 0.75rem;
+  padding: 0.35rem 0.65rem;
+  transition: background-color 0.2s ease;
+}
+
+.modal__close:hover {
+  background: #f1f5f9;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.dialog__message {
+  margin: 0 0 1.25rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+/* Grid */
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-grid--two {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 768px) {
+  .form-grid--two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  a:hover {
-    color: #747bff;
+}
+
+/* Utility */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.flex-gap-sm {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.flex-gap-md {
+  display: flex;
+  gap: 1rem;
+}
+
+.flex-justify-end {
+  justify-content: flex-end;
+}
+
+.flex-align-center {
+  align-items: center;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.mt-md {
+  margin-top: 1.5rem;
+}
+
+.mt-lg {
+  margin-top: 2rem;
+}
+
+.mb-sm {
+  margin-bottom: 0.75rem;
+}
+
+.mb-md {
+  margin-bottom: 1.5rem;
+}
+
+.shadow-soft {
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.18);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+}
+
+.table-wrapper table {
+  min-width: 680px;
+}
+
+.link-danger {
+  color: #dc2626;
+}
+
+.link-danger:hover {
+  color: #b91c1c;
+}
+
+.link-info {
+  color: #2563eb;
+}
+
+.link-info:hover {
+  color: #1d4ed8;
+}
+
+/* Empty states */
+.empty-state {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+/* Responsive tweaks */
+@media (max-width: 640px) {
+  .card,
+  .card--compact {
+    padding: 1.75rem;
   }
-  button {
-    background-color: #f9f9f9;
+
+  .page {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .navbar__inner {
+    gap: 1rem;
+    padding: 0 1rem;
+  }
+
+  .table {
+    min-width: 580px;
   }
 }

--- a/fractal-challenge/frontend/src/pages/AddOrder.jsx
+++ b/fractal-challenge/frontend/src/pages/AddOrder.jsx
@@ -19,14 +19,12 @@ export default function AddOrder() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [removeIndex, setRemoveIndex] = useState(null);
 
-  // Totales
   const totals = useMemo(() => {
     const productsCount = items.reduce((a, b) => a + Number(b.qty), 0);
     const finalPrice = items.reduce((a, b) => a + Number(b.totalPrice), 0);
     return { productsCount, finalPrice };
   }, [items]);
 
-  // Cargar productos y orden (si es edición)
   useEffect(() => {
     api.get("/products").then(res => setProducts(res.data));
 
@@ -51,11 +49,9 @@ export default function AddOrder() {
     }
   }, [id, isEdit]);
 
-  // Abrir modal para agregar
   const openAdd = () => { setEditIndex(null); setPickerOpen(true); };
   const openEdit = (idx) => { setEditIndex(idx); setPickerOpen(true); };
 
-  // Guardar producto del modal
   const saveFromPicker = (row) => {
     if (!row || !row.productId) return;
 
@@ -83,7 +79,6 @@ export default function AddOrder() {
     setConfirmOpen(false);
   };
 
-  // Guardar orden en backend
   const persist = async () => {
     if (!orderNumber.trim()) return alert("Order # is required");
     if (items.length === 0) return alert("Add at least one product");
@@ -93,120 +88,105 @@ export default function AddOrder() {
       items: items.map(it => ({ productId: it.productId, qty: it.qty }))
     };
 
-    console.log("👉 Enviando payload:", payload);
-
     try {
       if (isEdit) await api.put(`/orders/${id}`, payload);
       else await api.post("/orders", payload);
 
       navigate("/my-orders");
     } catch (e) {
-      console.error("❌ Error guardando:", e.response?.data || e.message);
       alert(e.response?.data?.message || "Error saving order");
     }
   };
 
   return (
-    <div className="max-w-6xl mx-auto mt-6 p-6 bg-white rounded-2xl shadow-lg space-y-6">
-      <h1 className="text-3xl font-extrabold text-gray-800">
-        {isEdit ? "✏️ Edit Order" : "➕ Add New Order"}
-      </h1>
+    <div className="page">
+      <div className="card stack">
+        <h1 className="page__title">{isEdit ? "✏️ Edit Order" : "➕ Add New Order"}</h1>
 
-      {/* Datos de la orden */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <label className="block text-gray-600 text-sm mb-1">Order Number</label>
-          <input
-            className="border rounded-lg w-full p-3 focus:ring focus:ring-blue-300"
-            value={orderNumber}
-            onChange={e => setOrderNumber(e.target.value)}
-          />
+        <div className="form-grid form-grid--two">
+          <div className="field">
+            <label>Order Number</label>
+            <input
+              className="input"
+              value={orderNumber}
+              onChange={e => setOrderNumber(e.target.value)}
+            />
+          </div>
+          <div className="field">
+            <label>Date</label>
+            <input
+              className="input input--muted"
+              value={dateString}
+              disabled
+            />
+          </div>
+          <div className="field">
+            <label># Products</label>
+            <input
+              className="input input--muted"
+              value={totals.productsCount}
+              disabled
+            />
+          </div>
+          <div className="field">
+            <label>Final Price</label>
+            <input
+              className="input input--muted input--strong"
+              value={`S/. ${totals.finalPrice.toFixed(2)}`}
+              disabled
+            />
+          </div>
         </div>
-        <div>
-          <label className="block text-gray-600 text-sm mb-1">Date</label>
-          <input
-            className="border rounded-lg w-full p-3 bg-gray-100"
-            value={dateString}
-            disabled
-          />
-        </div>
-        <div>
-          <label className="block text-gray-600 text-sm mb-1"># Products</label>
-          <input
-            className="border rounded-lg w-full p-3 bg-gray-100"
-            value={totals.productsCount}
-            disabled
-          />
-        </div>
-        <div>
-          <label className="block text-gray-600 text-sm mb-1">Final Price</label>
-          <input
-            className="border rounded-lg w-full p-3 bg-gray-100 font-bold text-green-700"
-            value={`S/. ${totals.finalPrice.toFixed(2)}`}
-            disabled
-          />
-        </div>
-      </div>
 
-      {/* Tabla de productos */}
-      <div className="flex justify-between items-center">
-        <h2 className="text-lg font-semibold text-gray-700">Products</h2>
-        <button
-          onClick={openAdd}
-          className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg shadow"
-        >
-          + Add Item
-        </button>
-      </div>
+        <div className="section-header">
+          <h2 className="section-title">Products</h2>
+          <button onClick={openAdd} className="btn btn--success">+ Add Item</button>
+        </div>
 
-      <div className="overflow-x-auto rounded border">
-        <table className="w-full text-left">
-          <thead className="bg-gray-100 text-gray-700 uppercase text-sm">
-            <tr>
-              <th className="p-2">ID</th>
-              <th className="p-2">Name</th>
-              <th className="p-2">Unit Price</th>
-              <th className="p-2">Qty</th>
-              <th className="p-2">Total Price</th>
-              <th className="p-2">Options</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((it, idx) => (
-              <tr key={idx} className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}>
-                <td className="p-2">{it.productId}</td>
-                <td className="p-2">{it.name}</td>
-                <td className="p-2">S/. {it.unitPrice}</td>
-                <td className="p-2">{it.qty}</td>
-                <td className="p-2 text-green-700 font-bold">S/. {it.totalPrice}</td>
-                <td className="p-2 flex gap-3">
-                  <button onClick={() => openEdit(idx)} className="text-blue-600 hover:underline">✏️ Edit</button>
-                  <button onClick={() => askRemove(idx)} className="text-red-600 hover:underline">🗑️ Remove</button>
-                </td>
-              </tr>
-            ))}
-            {items.length === 0 && (
+        <div className="table-wrapper">
+          <table className="table">
+            <thead>
               <tr>
-                <td colSpan="6" className="p-4 text-center text-gray-500">
-                  No products in this order.
-                </td>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Unit Price</th>
+                <th>Qty</th>
+                <th>Total Price</th>
+                <th>Options</th>
               </tr>
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {items.map((it, idx) => (
+                <tr key={idx}>
+                  <td>{it.productId}</td>
+                  <td>{it.name}</td>
+                  <td>S/. {it.unitPrice}</td>
+                  <td>{it.qty}</td>
+                  <td className="text-success">S/. {it.totalPrice}</td>
+                  <td className="actions">
+                    <button onClick={() => openEdit(idx)} className="btn btn--link">✏️ Edit</button>
+                    <button onClick={() => askRemove(idx)} className="btn btn--link btn--danger-link">🗑️ Remove</button>
+                  </td>
+                </tr>
+              ))}
+              {items.length === 0 && (
+                <tr>
+                  <td colSpan="6" className="table__empty">
+                    No products in this order.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex-gap-sm flex-justify-end">
+          <button onClick={persist} className="btn btn--primary">
+            💾 {isEdit ? "Update Order" : "Save Order"}
+          </button>
+        </div>
       </div>
 
-      {/* Botón Guardar */}
-      <div className="flex justify-end">
-        <button
-          onClick={persist}
-          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg shadow"
-        >
-          💾 {isEdit ? "Update Order" : "Save Order"}
-        </button>
-      </div>
-
-      {/* Modales */}
       <ProductPickerModal
         open={pickerOpen}
         products={products}

--- a/fractal-challenge/frontend/src/pages/AddProduct.jsx
+++ b/fractal-challenge/frontend/src/pages/AddProduct.jsx
@@ -16,49 +16,42 @@ export default function AddProduct() {
     try {
       await api.post("/products", { name, unitPrice: parseFloat(unitPrice) });
       alert("✅ Producto agregado con éxito");
-      navigate("/my-orders"); // redirige a tus órdenes
+      navigate("/my-orders");
     } catch (e) {
       alert(e.response?.data?.message || "Error al guardar");
     }
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen bg-gray-100 px-4">
-      <div className="bg-white shadow-lg rounded-2xl w-full max-w-md p-8">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
-          ➕ Agregar Producto
-        </h1>
-
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-600 mb-1">
-              Nombre del producto
-            </label>
+    <div className="page--full-center">
+      <div className="card card--compact" style={{ width: "min(100%, 420px)" }}>
+        <h1 className="card__title">➕ Agregar Producto</h1>
+        <div className="stack">
+          <div className="field">
+            <label>Nombre del producto</label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="input"
               placeholder="Ej: Laptop 14''"
             />
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-600 mb-1">
-              Precio unitario (S/.)
-            </label>
+          <div className="field">
+            <label>Precio unitario (S/.)</label>
             <input
               type="number"
               value={unitPrice}
               onChange={(e) => setUnitPrice(e.target.value)}
-              className="w-full p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="input"
               placeholder="Ej: 2500"
             />
           </div>
 
           <button
             onClick={saveProduct}
-            className="w-full bg-blue-600 text-white font-semibold py-3 rounded-lg shadow-md hover:bg-blue-700 transition"
+            className="btn btn--primary btn--full"
           >
             💾 Guardar Producto
           </button>

--- a/fractal-challenge/frontend/src/pages/MyOrders.jsx
+++ b/fractal-challenge/frontend/src/pages/MyOrders.jsx
@@ -5,7 +5,7 @@ import ConfirmDialog from "../components/ConfirmDialog";
 
 export default function MyOrders() {
   const [orders, setOrders] = useState([]);
-  const [target, setTarget] = useState(null); // id a borrar
+  const [target, setTarget] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const fetchOrders = async () => {
@@ -41,66 +41,51 @@ export default function MyOrders() {
   };
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-extrabold text-gray-800">📑 My Orders</h1>
-        <Link
-          to="/add-order"
-          className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg shadow transition"
-        >
-          + New Order
-        </Link>
+    <div className="page">
+      <div className="page__header">
+        <h1 className="page__title">📑 My Orders</h1>
+        <Link to="/add-order" className="btn btn--success">+ New Order</Link>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto bg-white rounded-xl shadow-md">
-        <table className="w-full text-left border-collapse">
-          <thead className="bg-gray-100 text-gray-700 uppercase text-sm">
+      <div className="table-container">
+        <table className="table">
+          <thead>
             <tr>
-              <th className="p-3">ID</th>
-              <th className="p-3">Order #</th>
-              <th className="p-3">Date</th>
-              <th className="p-3"># Products</th>
-              <th className="p-3">Final Price</th>
-              <th className="p-3">Status</th>
-              <th className="p-3">Options</th>
+              <th>ID</th>
+              <th>Order #</th>
+              <th>Date</th>
+              <th># Products</th>
+              <th>Final Price</th>
+              <th>Status</th>
+              <th>Options</th>
             </tr>
           </thead>
           <tbody>
-            {orders.map((o, idx) => (
-              <tr
-                key={o.id}
-                className={`border-t ${
-                  idx % 2 === 0 ? "bg-white" : "bg-gray-50"
-                }`}
-              >
-                <td className="p-3">{o.id}</td>
-                <td className="p-3 font-semibold">{o.orderNumber}</td>
-                <td className="p-3">{new Date(o.date).toLocaleString()}</td>
-                <td className="p-3">{o.productsCount}</td>
-                <td className="p-3 text-green-700 font-bold">S/. {o.finalPrice}</td>
-                <td className="p-3">
+            {orders.map((o) => (
+              <tr key={o.id}>
+                <td>{o.id}</td>
+                <td className="text-strong">{o.orderNumber}</td>
+                <td>{new Date(o.date).toLocaleString()}</td>
+                <td>{o.productsCount}</td>
+                <td className="text-success">S/. {o.finalPrice}</td>
+                <td>
                   <select
                     value={o.status}
                     onChange={(e) => handleStatus(o.id, e.target.value)}
-                    className="border rounded-lg p-2 bg-white focus:ring focus:ring-blue-300"
+                    className="select"
                   >
                     <option>Pending</option>
                     <option>InProgress</option>
                     <option>Completed</option>
                   </select>
                 </td>
-                <td className="p-3 flex gap-4">
-                  <Link
-                    to={`/add-order/${o.id}`}
-                    className="text-blue-600 hover:underline"
-                  >
+                <td className="actions">
+                  <Link to={`/add-order/${o.id}`} className="btn btn--link">
                     ✏️ Edit
                   </Link>
                   <button
                     onClick={() => askDelete(o)}
-                    className="text-red-600 hover:underline"
+                    className="btn btn--link btn--danger-link"
                   >
                     🗑️ Delete
                   </button>
@@ -109,10 +94,7 @@ export default function MyOrders() {
             ))}
             {orders.length === 0 && (
               <tr>
-                <td
-                  className="p-4 text-center text-gray-500"
-                  colSpan="7"
-                >
+                <td className="table__empty" colSpan="7">
                   No orders yet.
                 </td>
               </tr>
@@ -121,7 +103,6 @@ export default function MyOrders() {
         </table>
       </div>
 
-      {/* Confirm Dialog */}
       <ConfirmDialog
         open={confirmOpen}
         title="Delete order"

--- a/fractal-challenge/frontend/src/pages/Products.jsx
+++ b/fractal-challenge/frontend/src/pages/Products.jsx
@@ -6,7 +6,6 @@ export default function Products() {
   const [name, setName] = useState("");
   const [unitPrice, setUnitPrice] = useState("");
 
-  // cargar productos al inicio
   useEffect(() => {
     fetchProducts();
   }, []);
@@ -48,72 +47,79 @@ export default function Products() {
   };
 
   return (
-    <div className="max-w-4xl mx-auto mt-6 p-6 bg-white rounded-2xl shadow-lg">
-      {/* Título */}
-      <h1 className="text-3xl font-extrabold text-gray-800 mb-6">
-        📦 Productos
-      </h1>
+    <div className="page">
+      <div className="card stack">
+        <h1 className="page__title">📦 Productos</h1>
 
-      {/* Sección de agregar producto */}
-      <h2 className="text-xl font-bold text-gray-700 mb-3">➕ Agregar Producto</h2>
-      <div className="flex gap-4 mb-6">
-        <input
-          className="border rounded-lg p-2 flex-1"
-          placeholder="Nombre del producto"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <input
-          className="border rounded-lg p-2 w-32"
-          type="number"
-          placeholder="Precio"
-          value={unitPrice}
-          onChange={(e) => setUnitPrice(e.target.value)}
-        />
-        <button
-          onClick={addProduct}
-          className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg"
-        >
-          Guardar
-        </button>
+        <div className="stack">
+          <div>
+            <h2 className="section-title">➕ Agregar Producto</h2>
+            <div className="flex-gap-sm flex-wrap">
+              <input
+                className="input"
+                placeholder="Nombre del producto"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                style={{ flex: "1 1 220px" }}
+              />
+              <input
+                className="input"
+                type="number"
+                placeholder="Precio"
+                value={unitPrice}
+                onChange={(e) => setUnitPrice(e.target.value)}
+                style={{ width: "160px" }}
+              />
+              <button
+                onClick={addProduct}
+                className="btn btn--success"
+              >
+                Guardar
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="section-title">📋 Lista de Productos</h2>
+            <div className="table-wrapper">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Nombre</th>
+                    <th>Precio</th>
+                    <th>Opciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {products.map((p) => (
+                    <tr key={p.id}>
+                      <td>{p.id}</td>
+                      <td>{p.name}</td>
+                      <td>S/. {p.unitPrice}</td>
+                      <td className="actions">
+                        <button
+                          onClick={() => deleteProduct(p.id)}
+                          className="btn btn--link btn--danger-link"
+                        >
+                          🗑️ Eliminar
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {products.length === 0 && (
+                    <tr>
+                      <td colSpan="4" className="table__empty">
+                        No hay productos disponibles
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </div>
-
-      {/* Tabla de productos */}
-      <h2 className="text-xl font-bold text-gray-700 mb-3">📋 Lista de Productos</h2>
-      <table className="w-full border">
-        <thead className="bg-gray-100 text-gray-700 uppercase text-sm">
-          <tr>
-            <th className="p-2">ID</th>
-            <th className="p-2">Nombre</th>
-            <th className="p-2">Precio</th>
-            <th className="p-2">Opciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          {products.map((p) => (
-            <tr key={p.id} className="border-b">
-              <td className="p-2">{p.id}</td>
-              <td className="p-2">{p.name}</td>
-              <td className="p-2">S/. {p.unitPrice}</td>
-              <td className="p-2">
-                <button
-                  onClick={() => deleteProduct(p.id)}
-                  className="text-red-600 hover:underline"
-                >
-                  🗑️ Eliminar
-                </button>
-              </td>
-            </tr>
-          ))}
-          {products.length === 0 && (
-            <tr>
-              <td colSpan="4" className="text-center text-gray-500 p-4">
-                No hay productos disponibles
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the Tailwind-based PostCSS pipeline with a simple autoprefixer-only setup
- add a handcrafted global stylesheet that defines the app layout, component and utility classes
- update all UI components and pages to consume the new design system classes instead of Tailwind helpers

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d886d46b0c832f8e66fe2cc172b104